### PR TITLE
EditorConfig config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# Markdown
+[*.md]
+indent_size = 2
+
+# Python
+[*.py]
+indent_style = tab


### PR DESCRIPTION
For developers that have [the EditorConfig plugin](https://editorconfig.org/) for their editor. This will help prevent mixing tabs and spaces in the same file.

Set various options to what appears to be already the standard for this repository.