### PR TITLE
add config option to filter for language

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "lang": "en",
 	"site": "https://botsin.space",
 	"cw": null,
 	"learn_from_cw": false

--- a/functions.py
+++ b/functions.py
@@ -16,11 +16,11 @@ def make_sentence(output):
 
 	shutil.copyfile("toots.db", "toots-copy.db") #create a copy of the database because reply.py will be using the main one
 	db = sqlite3.connect("toots-copy.db")
-	db.text_factory=str
+	db.text_factory = str
 	c = db.cursor()
 	if cfg['learn_from_cw']:
 		toots = c.execute("SELECT content FROM `toots` ORDER BY RANDOM() LIMIT 10000").fetchall()
-	else: 
+	else:
 		toots = c.execute("SELECT content FROM `toots` WHERE cw = 0 ORDER BY RANDOM() LIMIT 10000").fetchall()
 	toots_str = ""
 	for toot in toots:


### PR DESCRIPTION
Hi,

this PR adds the ability to filter the toots that get downloaded for a specific language.

To accomplish this, the `lang` config value is added. Its default value is `en` and it can be set to any [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code or **`null`** (which results in toots of all (or undefined) languages being saved to the db).

I'm sorry if there already is some other way to lock the bot to a specific language, I was unable to find it in that case.