### PR TITLE
Add un/pin to the bot

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,9 @@ import os, sqlite3, signal, sys, json, re, shutil
 import requests
 import functions
 
-scopes = ["read:statuses", "read:accounts", "read:follows", "write:statuses", "read:notifications"]
+scopes = ["read:statuses", "read:accounts", "read:follows", "write:statuses", "read:notifications", "write:accounts"]
 #cfg defaults
+
 cfg = {
 	"site": "https://botsin.space",
 	"cw": None,
@@ -21,10 +22,10 @@ cfg = {
 	"mention_handling": 1,
 	"max_thread_length": 15
 }
+
 try:
 	cfg.update(json.load(open('config.json', 'r')))
 except:
-
 	shutil.copy2("config.sample.json", "config.json")
 	cfg.update(json.load(open('config.json', 'r')))
 

--- a/reply.py
+++ b/reply.py
@@ -59,10 +59,10 @@ class ReplyListener(mastodon.StreamListener):
 						if mention == "pin":
 							print("pin received, pinning")
 							client.status_pin(pin)
-							client.status_post("Toot pinned!", post_id, visibility=visibility spoiler_text = cfg['cw'])
+							client.status_post("Toot pinned!", post_id, visibility=visibility, spoiler_text = cfg['cw'])
 						else:
 							print("unpin received, unpinning")
-							client.status_post("Toot Unpinned!", post_id, visibility=visibility spoiler_text = cfg['cw'])
+							client.status_post("Toot unpinned!", post_id, visibility=visibility, spoiler_text = cfg['cw'])
 							client.status_unpin(pin)
 					else:
 						print("User is not valid")

--- a/reply.py
+++ b/reply.py
@@ -53,11 +53,16 @@ class ReplyListener(mastodon.StreamListener):
 				for user in validusers:
 					if user["id"] == notification["account"]["id"]: #user is #valid
 						print("User is valid")
+						visibility = notification['status']['visibility']
+						if visibility == "public":
+							visibility = "unlisted"
 						if mention == "pin":
 							print("pin received, pinning")
 							client.status_pin(pin)
+							client.status_post("Toot pinned!", post_id, visibility=visibility spoiler_text = cfg['cw'])
 						else:
 							print("unpin received, unpinning")
+							client.status_post("Toot Unpinned!", post_id, visibility=visibility spoiler_text = cfg['cw'])
 							client.status_unpin(pin)
 					else:
 						print("User is not valid")

--- a/reply.py
+++ b/reply.py
@@ -38,6 +38,7 @@ class ReplyListener(mastodon.StreamListener):
 			posts = 0
 			for post in context['ancestors']:
 				if post['account']['id'] == me:
+					pin = post["id"] #Only used if pin is called, but easier to call here
 					posts += 1
 					if posts >= cfg['max_thread_length']:
 						# stop replying
@@ -45,14 +46,30 @@ class ReplyListener(mastodon.StreamListener):
 						return
 
 			mention = extract_toot(notification['status']['content'])
-			toot = functions.make_toot(True)['toot'] #generate a toot
-			toot = acct + " " + toot #prepend the @
-			print(acct + " says " + mention) #logging
-			visibility = notification['status']['visibility']
-			if visibility == "public":
-				visibility = "unlisted"
-			client.status_post(toot, post_id, visibility=visibility, spoiler_text = cfg['cw']) #send toost
-			print("replied with " + toot) #logging
+			if (mention == "pin") or (mention == "unpin"): #check for keywords
+				print("Found pin/unpin")
+				#get a list of people the bot is following
+				validusers = client.account_following(me)
+				for user in validusers:
+					if user["id"] == notification["account"]["id"]: #user is #valid
+						print("User is valid")
+						if mention == "pin":
+							print("pin received, pinning")
+							client.status_pin(pin)
+						else:
+							print("unpin received, unpinning")
+							client.status_unpin(pin)
+					else:
+						print("User is not valid")
+			else:
+				toot = functions.make_toot(True)['toot'] #generate a toot
+				toot = acct + " " + toot #prepend the @
+				print(acct + " says " + mention) #logging
+				visibility = notification['status']['visibility']
+				if visibility == "public":
+					visibility = "unlisted"
+				client.status_post(toot, post_id, visibility=visibility, spoiler_text = cfg['cw']) #send toost
+				print("replied with " + toot) #logging
 
 rl = ReplyListener()
 client.stream_user(rl) #go!


### PR DESCRIPTION
Currently:
- Checks replies
- Checks in the user is being followed by the bot to see if it's a valid user
- Pins the replied toot if the user wants it to be pinned
- Unpins the replied toot if the user wants it to be unpinned
- Says that it has been pinned or unpinned

Possible features:
- Checks for status of pinned toots (EG Unpin on a toot thats not pinned fails)
- More verbose tooting?

Possible Issues:
- Had to add the edit account permission to allow pinning. This requires tokens to be regenerated. There is no way that I can see around this but might be able to check existing tokens and automatically regen? Idk tbh


I can add these before a merge but the basic functionality is there
